### PR TITLE
fix: resolve Dependabot auto-merge failures

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,8 +26,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 20
-          running-workflow-name: dependabot
-          allowed-conclusions: success
+          check-name: 'Run Tests'
+          allowed-conclusions: success,skipped
       
       # Skip major version updates as they might contain breaking changes
       # Skip akeyless updates as they will require manual

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,12 @@ on:
     paths:
       - 'tasks/akeyless-secrets/**/*'
       - '.github/workflows/main.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'tasks/akeyless-secrets/**/*'
+      - '.github/workflows/main.yml'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Problem

Two root causes were identified from the recent failed runs:

### 1. April 6 failure — `dependabot/fetch-metadata@v3` not found
Already fixed in the current file by pinning to `@v3.0.0`.

### 2. May 4 failure (recurring) — AzDO integration checks block auto-merge
The `lewagon/wait-on-check-action` was configured with `running-workflow-name: dependabot` (to exclude itself) but had no filter to exclude the **Azure DevOps pipeline checks** (`LanceMcCarthy.akeyless-extension-azdo`). Those AzDO checks run live integration tests that require real Akeyless secrets — secrets that Dependabot PRs cannot access — so they **always fail** on Dependabot PRs, permanently blocking auto-merge.

Additionally, `main.yml` only triggered on `push` to `main`, so **no GitHub Actions CI check ever ran** on Dependabot PRs, giving the wait step nothing valid to check.

## Fix

- **`main.yml`**: Add `pull_request` trigger (same path filters) so the `Run Tests` job runs on Dependabot PRs and validates the changes with lint + unit tests.
- **`dependabot-auto-merge.yml`**: Replace `running-workflow-name` with `check-name: 'Run Tests'` so the wait step targets only the GitHub Actions CI check and ignores the AzDO integration pipeline. Also adds `skipped` to `allowed-conclusions` to handle PRs where the path filter causes the job to be skipped (e.g. doc-only changes).