### PR TITLE
chore: suppress unfixable uuid security alert and add git workflow rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+      # uuid >= 9 dropped the uuid/v4 sub-path export that azure-pipelines-task-lib@5.x
+      # requires. The override cannot be applied until Microsoft updates task-lib.
+      # Track progress in: https://github.com/LanceMcCarthy/akeyless-extension-azdo/issues/99
+      - dependency-name: "uuid"
+        versions: [">=9.0.0"]
     groups:
        dependencies:
           applies-to: version-updates


### PR DESCRIPTION
## Summary

Dependabot has been repeatedly failing with `security_update_not_possible` for `uuid` because `azure-pipelines-task-lib@5.x` requires `uuid@^3.0.1` and calls the `uuid/v4` sub-path export that was removed in `uuid >= 9`. Forcing the override breaks all test suites at load time.

## Changes

- **`.github/dependabot.yml`** — adds an ignore rule for `uuid >= 9.0.0` to silence the unfixable alert, with a comment linking to tracking issue #99
- **`.github/copilot-instructions.md`** — adds a rule requiring explicit user approval before any `git commit` or `git push`

## Tracking

The uuid fix will be unblocked in issue #99 once Microsoft updates `azure-pipelines-task-lib` to support `uuid >= 9`.