### PR TITLE
ci: gate PR checks to trusted contributors only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,14 @@ jobs:
   build-and-test:
     runs-on: windows-latest
     name: Run Tests
+    # Only run automatically for trusted contributors. External contributors must have a
+    # maintainer manually approve the workflow run via the GitHub Actions UI.
+    # author_association values for trusted actors: OWNER, MEMBER, COLLABORATOR
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
     env:
         NODE_OPTIONS: "--max_old_space_size=4096"
     steps:


### PR DESCRIPTION
Stopgap defence against supply chain attacks. Adds author_association guard to main.yml so CI only auto-runs for OWNER/MEMBER/COLLABORATOR PRs. External PRs show the job as skipped until a maintainer approves. See PR description for full details.